### PR TITLE
Portability improvements

### DIFF
--- a/askap_cutout_daemon.py
+++ b/askap_cutout_daemon.py
@@ -238,12 +238,14 @@ def job_loop(targets, sbid, status_folder, src_beam_map, active_ids, active_ms, 
                 comp_name, array_id, len(active_ids), tgt_ms))
             # run_os_cmd('./make_askap_abs_cutout.sh {} {}'.format(array_id, status_folder))
             me = Path(__file__)
-            script = Path(me.parent, 'start_job.sh')
+            script = Path(me.parent, 'start_job.pbs')
+            script_folder = me.parent
 
             if use_pbs:
                 run_os_cmd(
-                    ('qsub -v COMP_INDEX={0},SBID={2},STATUS_DIR={3} -N "ASKAP_abs{0}" -o {1}/askap_abs_{0}_o.log '
-                     '-e {1}/askap_abs_{0}_e.log {4}').format(array_id, log_folder, sbid, status_folder, script))
+                    ('qsub -v COMP_INDEX={0},SBID={2},STATUS_DIR={3},SCRIPT_DIR={4} -N "ASKAP_abs{0}" -o {1}/askap_abs_{0}_o.log '
+                     '-e {1}/askap_abs_{0}_e.log {5}').format(array_id, log_folder, sbid, status_folder, script_folder, 
+                     script))
             else:
                 run_os_cmd('{} {} {} "{}"'.format(script, array_id, sbid, status_folder))
         elif not rate_limited:

--- a/list_beams.sh
+++ b/list_beams.sh
@@ -1,25 +1,15 @@
 #!/usr/bin/bash
-##### Select resources #####
-#PBS -N ASKAP_Abs_Prep
-#PBS -l select=1:ncpus=1
-#PBS -l place=vscatter
-#PBS -l walltime=1:00:00
-##### Queue #####
-#PBS -q smallmem
-##### Mail Options #####
-# Send an email at job start, end and if aborted
-#PBS -m a
-##### Change to your working directory #####
-cd /avatar/jdempsey/abs_cutouts
+# Produce a list of the beam measurement sets for an sbid, along with their beam centres
+# Measurement sets are located based on the location listed for the sbid in data_loc.csv in the working  directory
 
-date
+if [ $# -lt 1 ]; then
+  echo "Usage: ${0} sbid"
+  exit 1
+fi
 
-# If not run in PBS, get the sbid as the second param
-if [ -z "${SBID}" ]; then SBID=${1}; fi
+SBID=${1}
 export SBID
-
-#  Show list of CPUs you ran on, if you're running under PBS
-if [ -n "$PBS_NODEFILE" ]; then cat $PBS_NODEFILE; fi
+SCRIPTDIR=`dirname "$0"`
 
 ##### Execute Program #####
-casa -c list_beams.py
+casa -c ${SCRIPTDIR}/list_beams.py

--- a/start_job.pbs
+++ b/start_job.pbs
@@ -3,16 +3,23 @@
 #PBS -N ASKAP_Abs_Cutout
 #PBS -l select=1:ncpus=3:mem=40g
 #PBS -l place=vscatter
-#PBS -l walltime=10:00:00
+#PBS -l walltime=40:00:00
 ##### Queue #####
 #PBS -q smallmem
 ##### Mail Options #####
 # Send an email at job start, end and if aborted
 #PBS -m a
-##### Change to your working directory #####
-cd /avatar/jdempsey/abs_cutouts
 
 date
+
+# If running under PBS, switch to the working directory of the daemon
+if [ -n "${PBS_O_WORKDIR}" ]; then
+    cd "${PBS_O_WORKDIR}";
+fi
+pwd
+
+#  Show list of CPUs you ran on, if you're running under PBS
+if [ -n "$PBS_NODEFILE" ]; then cat $PBS_NODEFILE; fi
 
 # If not run in PBS, get the array id as the first param
 if [ -z "${COMP_INDEX}" ]; then COMP_INDEX=${1}; fi
@@ -23,8 +30,12 @@ if [ -z "${SBID}" ]; then SBID=${2}; fi
 # If not run in PBS, get the default status_dir
 if [ -z "${STATUS_DIR}" ]; then STATUS_DIR="status/${SBID}"; fi
 
+# If not run in PBS, set the script_dir to match where this script is. 
+# In PBS this will be a temporary location so we use the supplied value
+if [ -z "${SCRIPT_DIR}" ]; then SCRIPT_DIR=`dirname "$0"`; fi
+
 #  Show list of CPUs you ran on, if you're running under PBS
 if [ -n "$PBS_NODEFILE" ]; then cat $PBS_NODEFILE; fi
 
 ##### Execute Program #####
-bash ./make_askap_abs_cutout.sh ${COMP_INDEX} ${SBID} "${STATUS_DIR}"
+bash ${SCRIPT_DIR}/make_askap_abs_cutout.sh ${COMP_INDEX} ${SBID} "${STATUS_DIR}"


### PR DESCRIPTION
Updates to start_job and daemon to make them more portable.
* Rename start_job.sh to be abs specific (in preparation for slurm support)
* Pass in the script path and use the working directory of the daemon rather than use hardcoded paths.
* Also boost wall time to allow for larger data sets